### PR TITLE
updating the jira status

### DIFF
--- a/tap_jira/schemas/statuses.json
+++ b/tap_jira/schemas/statuses.json
@@ -5,105 +5,36 @@
       "object"
     ],
     "properties": {
-      "id": {
+      "status_id": {
         "type": [
           "null",
           "string"
         ]
       },
-      "name": {
+      "status_name": {
         "type": [
           "null",
           "string"
         ]
       },
-      "statusCategory": {
+      "status_category": {
         "type": [
           "null",
           "string"
         ]
       },
-      "scope": {
-        "title": "Scope",
+      "tenant": {
         "type": [
           "null",
-          "object"
+          "string"
+        ]
+      },
+      "inserted_at": {
+        "type": [
+          "null",
+          "string"
         ],
-        "properties": {
-          "type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "project": {
-            "type": [
-              "null",
-              "object"
-            ],
-            "properties": {
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        }
-      },
-      "description": {
-        "type": [
-          "null",
-          "string"
-        ]
-      },
-      "usages": {
-        "type": [
-          "null",
-          "array"
-        ],
-        "items": {
-          "type": [
-            "null",
-            "object"
-          ],
-          "properties": {
-            "project": {
-              "type": [
-                "null",
-                "object"
-              ],
-              "properties": {
-                "id": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                }
-              }
-            },
-            "issueTypes": {
-              "type": [
-                "null",
-                "array"
-              ],
-              "items": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        }
+        "format": "date-time"
       }
-    },
-    "inserted_at": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "date-time"
     }
 }

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -192,11 +192,38 @@ class IssuePriorities(Stream):
         self.write_page(priorities)
 
 class Statuses(Stream):
+    def _parse_status(self, status):
+        """Flatten a Jira status into the columns our warehouse expects, and
+        stamp the tenant (the search endpoint does not return it)."""
+        # statusCategory comes back in one of two shapes depending on the
+        # endpoint/version: a plain string enum ("TODO" / "IN_PROGRESS" /
+        # "DONE") on /statuses/search, or a nested object carrying a language
+        # -agnostic "key" ("new" / "indeterminate" / "done") on /status.
+        # Capture the scalar from either; the value is normalised to the
+        # issue-level vocabulary (new / indeterminate / done) downstream.
+        status_category = status.get('statusCategory')
+        if isinstance(status_category, dict):
+            status_category = status_category.get('key')
+        return {
+            'status_id': status.get('id'),
+            'status_name': status.get('name'),
+            'status_category': status_category,
+            'tenant': Context.config.get('site_name', 'default'),
+        }
+
+    def write_page(self, page):
+        super().write_page([self._parse_status(status) for status in page])
+
     def sync(self):
-        path="/rest/api/2/statuses/search"
-        response = Context.client.request(self.tap_stream_id, "GET", path)
-        priorities = response["values"]
-        self.write_page(priorities)
+        # /statuses/search is paginated (default maxResults ~50). The previous
+        # implementation read only the first page, silently dropping every
+        # status beyond it — which left intermediate workflow states (the very
+        # ones needed to derive "started"/"done") unmapped. Page through fully.
+        pager = Paginator(Context.client, items_key="values")
+        for page in pager.pages(self.tap_stream_id, "GET",
+                                "/rest/api/2/statuses/search",
+                                params={"maxResults": 200}):
+            self.write_page(page)
 
 
 class Issues(Stream):
@@ -413,7 +440,7 @@ ALL_STREAMS = [
     Stream("issue_types", ["id"], path="/rest/api/2/issuetype"),
     Stream("resolutions", ["id"], path="/rest/api/2/resolution"),
     Stream("roles", ["id"], path="/rest/api/2/role"),
-    Statuses("statuses", ["id"]),
+    Statuses("statuses", ["status_id", "tenant"]),
     IssuePriorities("issue_priorities", ["id"]),
     ISSUES,
     ISSUE_COMMENTS,


### PR DESCRIPTION
stream

# Description of change
(write a short description or paste a link to JIRA)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to statuses stream schema and primary key; downstream models or dedup logic keyed on `id` need updates, but the fix corrects incomplete data that could skew analytics.
> 
> **Overview**
> Fixes the **statuses** stream so it loads the full Jira status catalog instead of only the first API page, and reshapes records to match the warehouse.
> 
> Sync now pages through `/rest/api/2/statuses/search` with `Paginator` (`maxResults: 200`), addressing missing intermediate workflow states used for started/done mapping. Each record is flattened via `_parse_status`: `status_id`, `status_name`, `status_category` (string or nested `statusCategory.key`), plus `tenant` from `site_name`. The stream primary key is **`status_id` + `tenant`** (was `id`).
> 
> **`statuses.json`** drops nested `scope` and `usages` and renames fields to the flattened shape; `inserted_at` remains on records via the base `Stream.write_page`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a0e7c57fefa5084bb779d618eab4420d128dc49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->