### PR TITLE
revert the field title change, and fix inserted at date

### DIFF
--- a/tap_jira/schemas/statuses.json
+++ b/tap_jira/schemas/statuses.json
@@ -5,29 +5,98 @@
       "object"
     ],
     "properties": {
-      "status_id": {
+      "id": {
         "type": [
           "null",
           "string"
         ]
       },
-      "status_name": {
+      "name": {
         "type": [
           "null",
           "string"
         ]
       },
-      "status_category": {
+      "statusCategory": {
         "type": [
           "null",
           "string"
         ]
       },
-      "tenant": {
+      "scope": {
+        "title": "Scope",
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "project": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "description": {
         "type": [
           "null",
           "string"
         ]
+      },
+      "usages": {
+        "type": [
+          "null",
+          "array"
+        ],
+        "items": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "project": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "id": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            },
+            "issueTypes": {
+              "type": [
+                "null",
+                "array"
+              ],
+              "items": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            }
+          }
+        }
       },
       "inserted_at": {
         "type": [

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -192,33 +192,13 @@ class IssuePriorities(Stream):
         self.write_page(priorities)
 
 class Statuses(Stream):
-    def _parse_status(self, status):
-        """Flatten a Jira status into the columns our warehouse expects, and
-        stamp the tenant (the search endpoint does not return it)."""
-        # statusCategory comes back in one of two shapes depending on the
-        # endpoint/version: a plain string enum ("TODO" / "IN_PROGRESS" /
-        # "DONE") on /statuses/search, or a nested object carrying a language
-        # -agnostic "key" ("new" / "indeterminate" / "done") on /status.
-        # Capture the scalar from either; the value is normalised to the
-        # issue-level vocabulary (new / indeterminate / done) downstream.
-        status_category = status.get('statusCategory')
-        if isinstance(status_category, dict):
-            status_category = status_category.get('key')
-        return {
-            'status_id': status.get('id'),
-            'status_name': status.get('name'),
-            'status_category': status_category,
-            'tenant': Context.config.get('site_name', 'default'),
-        }
-
-    def write_page(self, page):
-        super().write_page([self._parse_status(status) for status in page])
-
     def sync(self):
         # /statuses/search is paginated (default maxResults ~50). The previous
         # implementation read only the first page, silently dropping every
         # status beyond it — which left intermediate workflow states (the very
-        # ones needed to derive "started"/"done") unmapped. Page through fully.
+        # ones needed to derive "started"/"done" downstream) unmapped. Page
+        # through fully. Records are written exactly as the API returns them
+        # (id, name, statusCategory, scope, description, usages).
         pager = Paginator(Context.client, items_key="values")
         for page in pager.pages(self.tap_stream_id, "GET",
                                 "/rest/api/2/statuses/search",
@@ -440,7 +420,7 @@ ALL_STREAMS = [
     Stream("issue_types", ["id"], path="/rest/api/2/issuetype"),
     Stream("resolutions", ["id"], path="/rest/api/2/resolution"),
     Stream("roles", ["id"], path="/rest/api/2/role"),
-    Statuses("statuses", ["status_id", "tenant"]),
+    Statuses("statuses", ["id"]),
     IssuePriorities("issue_priorities", ["id"]),
     ISSUES,
     ISSUE_COMMENTS,


### PR DESCRIPTION
# Description of change
(write a short description or paste a link to JIRA)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for consumers of the statuses table (column renames, dropped tenant, new PK) may require warehouse or dbt updates; issues stream still uses its own flattened status fields.
> 
> **Overview**
> The **statuses** stream stops flattening Jira responses into warehouse-specific columns (`status_id`, `status_name`, `status_category`, `tenant`) and instead emits the API payload as-is: `id`, `name`, `statusCategory`, plus nested **`scope`**, **`description`**, and **`usages`** reflected in the JSON schema.
> 
> **`Statuses`** no longer implements `_parse_status` or a custom `write_page`; pagination through `/rest/api/2/statuses/search` is unchanged, and records still get **`inserted_at`** from the base `Stream.write_page`. The stream primary key is simplified from **`status_id` + `tenant`** to **`id` only**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b41cd158dc1d618a91a0c25d4d6b87247c0760. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->